### PR TITLE
Extract Vendor and Product name

### DIFF
--- a/include/libusbp.h
+++ b/include/libusbp.h
@@ -112,6 +112,9 @@ enum libusbp_error_code
 
     /*! The device does not have a manufacturer. */
     LIBUSBP_ERROR_NO_MANUFACTURER = 9,
+
+    /*! The device does not have a name. */
+    LIBUSBP_ERROR_NO_NAME = 10,
 };
 
 /*! Attempts to copy an error.  If you copy a NULL ::libusbp_error
@@ -385,8 +388,6 @@ libusbp_error * libusbp_device_get_os_id(
     const libusbp_device *,
     char ** id);
 
-
-
 /*! Gets the name of the device manufacturer as an ASCII-encoded string.
  *
  * You should free the returned string by calling libusbp_string_free(). */
@@ -394,6 +395,14 @@ LIBUSBP_API LIBUSBP_WARN_UNUSED
 libusbp_error * libusbp_device_get_manufacturer(
     const libusbp_device * device,
     char ** manufacturer);
+
+/*! Gets the name of the device as an ASCII-encoded string.
+ *
+ * You should free the returned string by calling libusbp_string_free(). */
+LIBUSBP_API LIBUSBP_WARN_UNUSED
+libusbp_error * libusbp_device_get_name(
+    const libusbp_device * device,
+    char ** name);
 
 
 /** libusbp_generic_interface **************************************************/

--- a/include/libusbp.hpp
+++ b/include/libusbp.hpp
@@ -387,6 +387,16 @@ namespace libusbp
             libusbp_string_free(str);
             return manufacturer;
         }
+
+        /*! Wrapper for libusbp_device_get_name(). */
+        std::string get_name() const
+        {
+            char * str;
+            throw_if_needed(libusbp_device_get_name(pointer, &str));
+            std::string name = str;
+            libusbp_string_free(str);
+            return name;
+        }
     };
 
     /*! Wrapper for libusbp_list_connected_devices(). */


### PR DESCRIPTION
Hey, and thanks for a very useful library. I tried to follow the style used in the project, but I only have a Mac to test on, and not the reference USB device you listed either. I needed the vendor and product name, so I added them to the Device API.  Hopefully someone else can contribute the Linux/Win ports.