### PR TITLE
Clang tidy fixes

### DIFF
--- a/include/libusbp.hpp
+++ b/include/libusbp.hpp
@@ -107,7 +107,7 @@ namespace libusbp
     {
     public:
         /*! Constructor that takes a pointer. */
-        explicit unique_pointer_wrapper(T * p = NULL) noexcept
+        explicit unique_pointer_wrapper(T * p = nullptr) noexcept
             : pointer(p)
         {
         }
@@ -133,9 +133,9 @@ namespace libusbp
 
         /*! Implicit conversion to bool.  Returns true if the underlying pointer
          *  is not NULL. */
-        operator bool() const noexcept
+        explicit operator bool() const noexcept
         {
-            return pointer != NULL;
+            return pointer != nullptr;
         }
 
         /*! Returns the underlying pointer. */
@@ -146,19 +146,19 @@ namespace libusbp
 
         /*! Sets the underlying pointer to the specified value, freeing the
          * previous pointer and taking ownership of the specified one. */
-        void pointer_reset(T * p = NULL) noexcept
+        void pointer_reset(T * p = nullptr) noexcept
         {
             pointer_free(pointer);
             pointer = p;
         }
 
         /*! Releases the pointer, transferring ownership of it to the caller and
-         * resetting the underlying pointer of this object to NULL.  The caller
+         * resetting the underlying pointer of this object to nullptr.  The caller
          * is responsible for freeing the returned pointer if it is not NULL. */
         T * pointer_release() noexcept
         {
             T * p = pointer;
-            pointer = NULL;
+            pointer = nullptr;
             return p;
         }
 
@@ -193,14 +193,14 @@ namespace libusbp
     {
     public:
         /*! Constructor that takes a pointer. */
-        explicit unique_pointer_wrapper_with_copy(T * p = NULL) noexcept
+        explicit unique_pointer_wrapper_with_copy(T * p = nullptr) noexcept
             : unique_pointer_wrapper<T>(p)
         {
         }
 
         /*! Move constructor. */
         unique_pointer_wrapper_with_copy(
-            unique_pointer_wrapper_with_copy && other) = default;
+            unique_pointer_wrapper_with_copy && other) noexcept = default;
 
         /*! Copy constructor */
         unique_pointer_wrapper_with_copy(
@@ -228,14 +228,13 @@ namespace libusbp
     {
     public:
         /*! Constructor that takes a pointer.  */
-        explicit error(libusbp_error * p = NULL) noexcept
+        explicit error(libusbp_error * p = nullptr) noexcept
             : unique_pointer_wrapper_with_copy(p)
         {
         }
 
         /*! Wrapper for libusbp_error_get_message(). */
-        virtual const char * what() const noexcept
-        {
+        const char * what() const noexcept override {
             return libusbp_error_get_message(pointer);
         }
 
@@ -256,7 +255,7 @@ namespace libusbp
     /*! \cond */
     inline void throw_if_needed(libusbp_error * err)
     {
-        if (err != NULL)
+        if (err != nullptr)
         {
             throw error(err);
         }
@@ -268,7 +267,7 @@ namespace libusbp
     {
     public:
         /*! Constructor that takes a pointer. */
-        explicit async_in_pipe(libusbp_async_in_pipe * pointer = NULL)
+        explicit async_in_pipe(libusbp_async_in_pipe * pointer = nullptr)
             : unique_pointer_wrapper(pointer)
         {
         }
@@ -304,8 +303,8 @@ namespace libusbp
         bool handle_finished_transfer(void * buffer, size_t * transferred,
             error * transfer_error)
         {
-            libusbp_error ** error_out = NULL;
-            if (transfer_error != NULL)
+            libusbp_error ** error_out = nullptr;
+            if (transfer_error != nullptr)
             {
                 transfer_error->pointer_reset();
                 error_out = transfer_error->pointer_to_pointer_get();
@@ -329,7 +328,7 @@ namespace libusbp
     {
     public:
         /*! Constructor that takes a pointer. */
-        explicit device(libusbp_device * pointer = NULL) :
+        explicit device(libusbp_device * pointer = nullptr) :
             unique_pointer_wrapper_with_copy(pointer)
         {
         }
@@ -388,7 +387,7 @@ namespace libusbp
         std::vector<device> vector;
         for(size_t i = 0; i < size; i++)
         {
-            vector.push_back(device(device_list[i]));
+            vector.emplace_back(device_list[i]);
         }
         libusbp_list_free(device_list);
         return vector;
@@ -409,13 +408,13 @@ namespace libusbp
     public:
         /*! Constructor that takes a pointer.  This object will free the pointer
          *  when it is destroyed. */
-        explicit generic_interface(libusbp_generic_interface * pointer = NULL)
+        explicit generic_interface(libusbp_generic_interface * pointer = nullptr)
             : unique_pointer_wrapper_with_copy(pointer)
         {
         }
 
         /*! Wrapper for libusbp_generic_interface_create. */
-        generic_interface(const device & device,
+        explicit generic_interface(const device & device,
             uint8_t interface_number = 0, bool composite = false)
         {
             throw_if_needed(libusbp_generic_interface_create(
@@ -449,13 +448,13 @@ namespace libusbp
     public:
         /*! Constructor that takes a pointer.  This object will free the pointer
          *  when it is destroyed. */
-        explicit generic_handle(libusbp_generic_handle * pointer = NULL) noexcept
+        explicit generic_handle(libusbp_generic_handle * pointer = nullptr) noexcept
             : unique_pointer_wrapper(pointer)
         {
         }
 
         /*! Wrapper for libusbp_generic_handle_open(). */
-        generic_handle(const generic_interface & gi)
+        explicit generic_handle(const generic_interface & gi)
         {
             throw_if_needed(libusbp_generic_handle_open(gi.pointer_get(), &pointer));
         }
@@ -487,9 +486,9 @@ namespace libusbp
             uint8_t bRequest,
             uint16_t wValue,
             uint16_t wIndex,
-            void * buffer = NULL,
+            void * buffer = nullptr,
             uint16_t wLength = 0,
-            size_t * transferred = NULL)
+            size_t * transferred = nullptr)
         {
             throw_if_needed(libusbp_control_transfer(pointer,
                 bmRequestType, bRequest, wValue, wIndex,
@@ -543,13 +542,13 @@ namespace libusbp
     public:
         /*! Constructor that takes a pointer.  This object will free the pointer
          *  when it is destroyed. */
-        explicit serial_port(libusbp_serial_port * pointer = NULL)
+        explicit serial_port(libusbp_serial_port * pointer = nullptr)
             : unique_pointer_wrapper_with_copy(pointer)
         {
         }
 
         /*! Wrapper for libusbp_serial_port_create(). */
-        serial_port(const device & device,
+        explicit serial_port(const device & device,
             uint8_t interface_number = 0, bool composite = false)
         {
             throw_if_needed(libusbp_serial_port_create(

--- a/src/error.c
+++ b/src/error.c
@@ -124,7 +124,7 @@ libusbp_error * error_add_v(libusbp_error * error, const char * format, va_list 
         int result = vsnprintf(x, 0, format, ap2);
         if (result > 0)
         {
-            outer_message_length = result;
+            outer_message_length = (size_t) result;
         }
         va_end(ap2);
     }

--- a/src/find_device.c
+++ b/src/find_device.c
@@ -37,10 +37,7 @@ libusbp_error * libusbp_find_device_with_vid_pid(
 
     libusbp_device ** new_list = NULL;
     size_t size = 0;
-    if (error == NULL)
-    {
-        error = libusbp_list_connected_devices(&new_list, &size);
-    }
+    error = libusbp_list_connected_devices(&new_list, &size);
 
     assert(error != NULL || new_list != NULL);
 

--- a/src/mac/async_in_transfer_mac.c
+++ b/src/mac/async_in_transfer_mac.c
@@ -51,14 +51,11 @@ libusbp_error * async_in_transfer_create(
     libusbp_error * error = NULL;
 
     // Allocate memory for the transfer struct.
-    async_in_transfer * new_transfer = NULL;
-    if (error == NULL)
+    async_in_transfer * new_transfer = calloc(1, sizeof(async_in_transfer));
+
+    if (new_transfer == NULL)
     {
-        new_transfer = calloc(1, sizeof(async_in_transfer));
-        if (new_transfer == NULL)
-        {
-            error = &error_no_memory;
-        }
+        error = &error_no_memory;
     }
 
     // Allocate memory for the buffer.

--- a/src/mac/device_mac.c
+++ b/src/mac/device_mac.c
@@ -25,14 +25,9 @@ libusbp_error * create_device(io_service_t service, libusbp_device ** device)
     assert(service != MACH_PORT_NULL);
     assert(device != NULL);
 
-    libusbp_error * error = NULL;
-
     // Allocate the device.
     libusbp_device * new_device = NULL;
-    if (error == NULL)
-    {
-        error = device_allocate(&new_device);
-    }
+    libusbp_error * error = device_allocate(&new_device);
 
     // Get the numeric IDs.
     if (error == NULL)
@@ -89,10 +84,7 @@ libusbp_error * libusbp_device_copy(const libusbp_device * source, libusbp_devic
 
     // Allocate the device.
     libusbp_device * new_device = NULL;
-    if (error == NULL)
-    {
-        error = device_allocate(&new_device);
-    }
+    error = device_allocate(&new_device);
 
     // Copy the simple fields, while leaving the pointers owned by the
     // device NULL so that libusbp_device_free is still OK to call.

--- a/src/mac/generic_handle_mac.c
+++ b/src/mac/generic_handle_mac.c
@@ -63,8 +63,9 @@ static libusbp_error * process_pipe_properties(libusbp_generic_handle * handle)
         uint8_t transfer_type;
         uint16_t max_packet_size;
         uint8_t interval;
-        kern_return_t kr = (*handle->ioh)->GetPipeProperties(handle->ioh, i,
-            &direction, &endpoint_number, &transfer_type, &max_packet_size, &interval);
+        kr = (*handle->ioh)->GetPipeProperties(handle->ioh, (UInt8) i,
+          &direction, &endpoint_number, &transfer_type, &max_packet_size, &interval);
+
         if (kr != KERN_SUCCESS)
         {
             return error_create_mach(kr, "Failed to get pipe properties for pipe %d.", i);
@@ -74,11 +75,11 @@ static libusbp_error * process_pipe_properties(libusbp_generic_handle * handle)
         {
             if (direction)
             {
-                handle->in_pipe_index[endpoint_number] = i;
+                handle->in_pipe_index[endpoint_number] = (uint8_t) i;
             }
             else
             {
-                handle->out_pipe_index[endpoint_number] = i;
+                handle->out_pipe_index[endpoint_number] = (uint8_t) i;
             }
         }
     }
@@ -95,14 +96,11 @@ static libusbp_error * set_configuration(io_service_t service)
     // Turn io_service_t into something we can actually use.
     IOUSBDeviceInterface ** dev_handle = NULL;
     IOCFPlugInInterface ** plug_in = NULL;
-    if (error == NULL)
-    {
-        error = service_to_interface(service,
-            kIOUSBDeviceUserClientTypeID,
-            CFUUIDGetUUIDBytes(kIOUSBDeviceInterfaceID197),
-            (void **)&dev_handle,
-            &plug_in);
-    }
+    error = service_to_interface(service,
+        kIOUSBDeviceUserClientTypeID,
+        CFUUIDGetUUIDBytes(kIOUSBDeviceInterfaceID197),
+        (void **)&dev_handle,
+        &plug_in);
 
     uint8_t config_num = 0;
     if (error == NULL)
@@ -172,10 +170,7 @@ static libusbp_error * set_configuration_and_get_service(
 
     // Get an io_service_t for the physical device.
     io_service_t device_service = MACH_PORT_NULL;
-    if (error == NULL)
-    {
-        error = service_get_from_id(device_id, &device_service);
-    }
+    error = service_get_from_id(device_id, &device_service);
 
     // Set the configruation to 1 if it is not set.
     if (error == NULL)
@@ -214,13 +209,11 @@ libusbp_error * libusbp_generic_handle_open(
 
     // Allocate memory for the handle.
     libusbp_generic_handle * new_handle = NULL;
-    if (error == NULL)
+    new_handle = calloc(1, sizeof(libusbp_generic_handle));
+
+    if (new_handle == NULL)
     {
-        new_handle = calloc(1, sizeof(libusbp_generic_handle));
-        if (new_handle == NULL)
-        {
-            error = &error_no_memory;
-        }
+        error = &error_no_memory;
     }
 
     // Get the io_service_t representing the IOUSBInterface.
@@ -330,14 +323,11 @@ libusbp_error * libusbp_generic_handle_set_timeout(
 
     libusbp_error * error = NULL;
 
-    if (error == NULL)
-    {
-        error = check_pipe_id(pipe_id);
-    }
+    error = check_pipe_id(pipe_id);
 
     if (error == NULL)
     {
-        uint8_t endpoint_number = pipe_id & MAX_ENDPOINT_NUMBER;
+        uint8_t endpoint_number = pipe_id & (uint8_t) MAX_ENDPOINT_NUMBER;
 
         if (pipe_id & 0x80)
         {
@@ -411,7 +401,7 @@ libusbp_error * libusbp_read_pipe(
 
     libusbp_error * error = NULL;
 
-    if (error == NULL && size == 0)
+    if (size == 0)
     {
         error = error_create("Transfer size 0 is not allowed.");
     }
@@ -433,12 +423,12 @@ libusbp_error * libusbp_read_pipe(
 
     if (error == NULL)
     {
-        uint8_t endpoint_number = pipe_id & MAX_ENDPOINT_NUMBER;
+        uint8_t endpoint_number = pipe_id & (uint8_t) MAX_ENDPOINT_NUMBER;
         uint32_t no_data_timeout = 0;
         uint32_t completion_timeout = handle->in_timeout[endpoint_number];
-        uint32_t iokit_size = size;
+        uint32_t iokit_size = (uint32_t) size;
         uint32_t pipe_index = handle->in_pipe_index[endpoint_number];
-        kern_return_t kr = (*handle->ioh)->ReadPipeTO(handle->ioh, pipe_index,
+        kern_return_t kr = (*handle->ioh)->ReadPipeTO(handle->ioh, (UInt8) pipe_index,
           buffer, &iokit_size, no_data_timeout, completion_timeout);
         if (transferred != NULL) { *transferred = iokit_size; }
         if (kr != KERN_SUCCESS)
@@ -474,7 +464,7 @@ libusbp_error * libusbp_write_pipe(
 
     libusbp_error * error = NULL;
 
-    if (error == NULL && size > UINT32_MAX)
+    if (size > UINT32_MAX)
     {
         error = error_create("Transfer size is too large.");
     }
@@ -491,12 +481,12 @@ libusbp_error * libusbp_write_pipe(
 
     if (error == NULL)
     {
-        uint8_t endpoint_number = pipe_id & MAX_ENDPOINT_NUMBER;
+        uint8_t endpoint_number = pipe_id & (uint8_t) MAX_ENDPOINT_NUMBER;
         uint32_t no_data_timeout = 0;
         uint32_t completion_timeout = handle->out_timeout[endpoint_number];
         uint32_t pipe_index = handle->out_pipe_index[endpoint_number];
-        kern_return_t kr = (*handle->ioh)->WritePipeTO(handle->ioh, pipe_index,
-          (void *)buffer, size, no_data_timeout, completion_timeout);
+        kern_return_t kr = (*handle->ioh)->WritePipeTO(handle->ioh, (UInt8) pipe_index,
+          (void *)buffer, (UInt32) size, no_data_timeout, completion_timeout);
         if (kr != KERN_SUCCESS)
         {
             error = error_create_mach(kr, "");
@@ -598,7 +588,7 @@ IOUSBInterfaceInterface182 ** generic_handle_get_ioh(const libusbp_generic_handl
 
 uint8_t generic_handle_get_pipe_index(const libusbp_generic_handle * handle, uint8_t pipe_id)
 {
-    uint8_t endpoint_number = pipe_id & MAX_ENDPOINT_NUMBER;
+    uint8_t endpoint_number = pipe_id & (uint8_t) MAX_ENDPOINT_NUMBER;
     if (pipe_id & 0x80)
     {
         return handle->in_pipe_index[endpoint_number];

--- a/src/mac/generic_interface_mac.c
+++ b/src/mac/generic_interface_mac.c
@@ -82,10 +82,7 @@ libusbp_error * libusbp_generic_interface_create(
     {
         // Get an io_service_t for the physical device.
         io_service_t device_service = MACH_PORT_NULL;
-        if (error == NULL)
-        {
-            error = service_get_from_id(new_gi->device_id, &device_service);
-        }
+        error = service_get_from_id(new_gi->device_id, &device_service);
 
         // Get the io_service_t for the interface.
         io_service_t interface_service = MACH_PORT_NULL;
@@ -149,10 +146,7 @@ libusbp_error * libusbp_generic_interface_copy(
 
     // Allocate the generic interface.
     libusbp_generic_interface * new_gi = NULL;
-    if (error == NULL)
-    {
-        error = generic_interface_allocate(&new_gi);
-    }
+    error = generic_interface_allocate(&new_gi);
 
     // Copy the simple fields.
     if (error == NULL)

--- a/src/mac/list_mac.c
+++ b/src/mac/list_mac.c
@@ -37,13 +37,10 @@ libusbp_error * libusbp_list_connected_devices(
     // Create a dictionary that says "IOProviderClass" => "IOUSBDevice"
     // This dictionary is CFReleased by IOServiceGetMatchingServices.
     CFMutableDictionaryRef dict = NULL;
-    if (error == NULL)
+    dict = IOServiceMatching("IOUSBHostDevice");
+    if (dict == NULL)
     {
-        dict = IOServiceMatching("IOUSBHostDevice");
-        if (dict == NULL)
-        {
-            error = error_create("IOServiceMatching returned null.");
-        }
+        error = error_create("IOServiceMatching returned null.");
     }
 
     // Create an iterator for all the connected USB devices.

--- a/src/mac/serial_port_mac.c
+++ b/src/mac/serial_port_mac.c
@@ -41,14 +41,11 @@ libusbp_error * libusbp_serial_port_create(
 
     libusbp_error * error = NULL;
 
-    libusbp_serial_port * new_port = NULL;
-    if (error == NULL)
+    libusbp_serial_port * new_port = calloc(1, sizeof(libusbp_serial_port));
+
+    if (new_port == NULL)
     {
-        new_port = calloc(1, sizeof(libusbp_serial_port));
-        if (new_port == NULL)
-        {
-            error = &error_no_memory;
-        }
+        error = &error_no_memory;
     }
 
     // Get the ID for the physical device.
@@ -128,14 +125,11 @@ libusbp_error * libusbp_serial_port_copy(const libusbp_serial_port * source,
     libusbp_error * error = NULL;
 
     // Allocate memory for the new object.
-    libusbp_serial_port * new_port = NULL;
-    if (error == NULL)
+    libusbp_serial_port * new_port = calloc(1, sizeof(libusbp_serial_port));
+
+    if (new_port == NULL)
     {
-        new_port = calloc(1, sizeof(libusbp_serial_port));
-        if (new_port == NULL)
-        {
-            error = &error_no_memory;
-        }
+        error = &error_no_memory;
     }
 
     // Copy the port name.


### PR DESCRIPTION
Used clang-tidy autofixes from CLion. Mostly pedantic/redundant fixes, but less warnings popping up means the real problems are easier to spot later :)