### PR TITLE
[feature] Added cmake uninstall target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,3 +128,19 @@ endif ()
 if (WIN32)
   add_subdirectory (install_helper)
 endif ()
+
+###
+# Uninstall target
+###
+
+if (NOT TARGET uninstall)
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake"
+        IMMEDIATE @ONLY
+        )
+    add_custom_target(
+        uninstall COMMAND ${CMAKE_COMMAND}
+        -P ${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake
+        )
+endif ()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 The following tools are used to help build, test, debug, and document this library:
 
-- USB Test Device A: This is a custom USB device that is used for testing this library.  You must have a device like this plugged in if you want to run the full test suite.  The `test/firmware/wixel` folder contains firmware that can turn a [Pololu Wixel](https://www.pololu.com/product/1337) into a USB Test Device A, and it should be possible to implement it on other USB-capable boards as well.
+- USB Test Device A: This is a custom USB device that is used for testing this library. You must have a device like this plugged in if you want to run the full test suite.  The `test/firmware/wixel` folder contains firmware that can turn a [Pololu Wixel](https://www.pololu.com/product/1337) into a USB Test Device A, and it should be possible to implement it on other USB-capable boards as well.
 - [cmake](http://www.cmake.org)
 - [catch](https://github.com/philsquared/Catch)
 - [Doxygen](http://www.stack.nl/~dimitri/doxygen/)

--- a/README.md
+++ b/README.md
@@ -34,48 +34,65 @@ The library runs on:
 
 The library only supports certain types of USB devices.
 
-On Windows, any generic interface that you want to access with this library must use WinUSB as its driver, so you will need to provide a driver package or use some other mechanism to make sure WinUSB is installed.  The generic interface must have a registry key named "DeviceInterfaceGUIDs" which is a REG_MULTI_SZ, and the first string in the key must be a valid GUID.  The "DeviceInterfaceGUID" key is not supported.
+On Windows, any generic interface that you want to access with this library must use WinUSB as its driver,
+so you will need to provide a driver package or use some other mechanism to make sure WinUSB is installed.
+The generic interface must have a registry key named "DeviceInterfaceGUIDs" which is a REG_MULTI_SZ, and
+the first string in the key must be a valid GUID.  The "DeviceInterfaceGUID" key is not supported.
 
 Both composite and non-composite devices are supported.
 
-There is no support for switching device configurations or switching between alternate settings of an interface.
+There is no support for switching device configurations or switching between alternate settings of an
+interface.
 
-There is no support for accessing a generic interface that is included in an interface association and is not the first interface in the association.
+There is no support for accessing a generic interface that is included in an interface association and is
+not the first interface in the association.
 
 
 ## Platform differences
 
-This library is a relatively simple wrapper around low-level USB APIs provided by each supported platform.  Because these APIs have different capabilities and behavior, you should not assume your program will work on a platform on which it has not been tested.  Some notable differences are documented in `PLATFORM_NOTES.md`.
+This library is a relatively simple wrapper around low-level USB APIs provided by each supported platform.
+Because these APIs have different capabilities and behavior, you should not assume your program will work
+on a platform on which it has not been tested.  Some notable differences are documented in `PLATFORM_NOTES.md`.
 
 
 ## Comparison to libusb
 
-This library has a lot in common with [libusb 1.0](http://libusb.info/), which has been around for longer and has many more features.  However, libusbp does have some useful features that libusb lacks, such as listing the serial number of a USB device without performing I/O or getting information about a USB device's virtual serial ports.
+This library has a lot in common with [libusb 1.0](http://libusb.info/), which has been around for longer
+and has many more features.  However, libusbp does have some useful features that libusb lacks, such as
+listing the serial number of a USB device without performing I/O or getting information about a USB device's
+virtual serial ports.
 
 
 ## Building from source on Windows with MSYS2
 
-The recommended way to build this library on Windows is to use [MSYS2](http://msys2.github.io/).  These instructions assume you are building a 32-bit binary.
+The recommended way to build this library on Windows is to use [MSYS2](http://msys2.github.io/).
+These instructions assume you are building a 32-bit binary.
 
-After installing MSYS2, select "MinGW-w64 Win32 shell" from the Start Menu.  Then run this command to install the required packages:
+After installing MSYS2, select "MinGW-w64 Win32 shell" from the Start Menu.
+Then run this command to install the required packages:
 
     pacman -S mingw-w64-i686-toolchain mingw-w64-i686-cmake
 
-Download the source code of this library and navigate to the top-level directory using `cd`.  Then run these commands to build the library and install it:
+Download the source code of this library and navigate to the top-level directory using `cd`.
+Then run these commands to build the library and install it:
 
     mkdir build
     cd build
     MSYS2_ARG_CONV_EXCL=- cmake .. -G"MSYS Makefiles" -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX
     make install DESTDIR=/
 
-We currently do not provide any build files for Visual Studio.  You can use CMake to generate Visual Studio build files, and the library and its examples will probably compile, but we have not tested the resulting library.
+We currently do not provide any build files for Visual Studio.  You can use CMake to generate
+Visual Studio build files, and the library and its examples will probably compile, but we have not
+tested the resulting library.
 
 
 ## Building from source on Linux
 
-First, you will need to make sure that you have a suitable compiler installed, such as gcc.  You can run `gcc -v` in a shell to make sure it is available.
+First, you will need to make sure that you have a suitable compiler installed, such as gcc.
+You can run `gcc -v` in a shell to make sure it is available.
 
-You will also need to install CMake and libudev.  On Ubuntu, Raspbian, and other Debian-based distributions, the command to do this is:
+You will also need to install CMake and libudev.  On Ubuntu, Raspbian, and other Debian-based
+distributions, the command to do this is:
 
     sudo apt-get install cmake libudev-dev
 
@@ -83,7 +100,8 @@ On Arch Linux, libudev should already be installed, and you can install CMake by
 
     sudo pacman -S cmake
 
-Download the source code of this library and navigate to the top-level directory using `cd`.  Then run these commands to build the library and install it:
+Download the source code of this library and navigate to the top-level directory using `cd`.
+Then run these commands to build the library and install it:
 
     mkdir build
     cd build
@@ -94,11 +112,13 @@ Download the source code of this library and navigate to the top-level directory
 
 ## Building from source on macOS
 
-First, install [Homebrew](http://brew.sh/), a package manager for macOS.  Then use Homebrew to install CMake by running the following command in a Terminal:
+First, install [Homebrew](http://brew.sh/), a package manager for macOS.  Then use Homebrew
+to install CMake by running the following command in a Terminal:
 
     brew install cmake
 
-Download the source code of this library and navigate to the top-level directory using `cd`.  Then run these commands in a Terminal to build the library and install it:
+Download the source code of this library and navigate to the top-level directory using `cd`.
+Then run these commands in a Terminal to build the library and install it:
 
     mkdir build
     cd build
@@ -107,17 +127,29 @@ Download the source code of this library and navigate to the top-level directory
     sudo make install
 
 
+## Uninstalling
+
+In order to uninstall this library, open a terminal and navigate to the build folder within
+this source code project using `cd` and enter the following command:
+
+    sudo make uninstall
+    
+
 ## Incorporating libusbp into a C/C++ project
 
-The first step to incorporating libusbp into another project is to add the libusbp header folder to your project's include search path.
-The header folder is the folder that contains `libusbp.h` and `libusbp.hpp`, and it will typically be named `libusbp-1`.
-On systems with `pkg-config`, assuming libusbp has been installed properly, you can run the following command to get the include directory:
+The first step to incorporating libusbp into another project is to add the libusbp header
+folder to your project's include search path. The header folder is the folder that contains
+`libusbp.h` and `libusbp.hpp`, and it will typically be named `libusbp-1`.
+On systems with `pkg-config`, assuming libusbp has been installed properly, you can run the
+following command to get the include directory:
 
     pkg-config --cflags libusbp-1
 
-The output of that command is formatted so that it can be directly added to the command-line arguments for most compilers.
+The output of that command is formatted so that it can be directly added to the command-line
+arguments for most compilers.
 
-Next, you should include the appropriate libusbp header in your source code by adding an include directive at the top of one of your source files.
+Next, you should include the appropriate libusbp header in your source code by adding an
+include directive at the top of one of your source files.
 To use the C API from a C or C++ project, you should write:
 
     #include <libusbp.h>
@@ -127,23 +159,30 @@ To use the C++ API from a C++ project, you should write:
     #include <libusbp.hpp>
 
 After making the changes above, you should be able compile your project successfully.
-If the compiler says that the libusbp header file cannot be found, make sure you have specified the include path correctly as described above.
+If the compiler says that the libusbp header file cannot be found, make sure you have specified
+the include path correctly as described above.
 
-If you add a call to any of the libusbp functions and rebuild, you will probably get an undefined reference error from the linker.  To fix this, you need to add libusbp's linker settings to your project.  To get the linker settings, run:
+If you add a call to any of the libusbp functions and rebuild, you will probably get an undefined
+reference error from the linker.  To fix this, you need to add libusbp's linker settings to your
+project. To get the linker settings, run:
 
     pkg-config --libs libusbp-1
 
-If you are using GCC and a shell that supports Bash-like syntax, here is an example command that compiles a single-file C program using the correct compiler and linker settings:
+If you are using GCC and a shell that supports Bash-like syntax, here is an example command that
+compiles a single-file C program using the correct compiler and linker settings:
 
     gcc program.c `pkg-config --cflags --libs libusbp-1`
 
-Here is an equivalent command for C++.  Note that we use the `--std=gnu++11` option because the libusbp C++ API requires features from C++11:
+Here is an equivalent command for C++.  Note that we use the `--std=gnu++11` option because the
+libusbp C++ API requires features from C++11:
 
     g++ --std=gnu++11 program.cpp `pkg-config --cflags --libs libusbp-1`
 
-The order of the arguments above matters: the user program must come before libusbp because it relies on symbols that are defined by libusbp.
+The order of the arguments above matters: the user program must come before libusbp because it
+relies on symbols that are defined by libusbp.
 
-The `examples` folder of this repository contains some example code that uses libusbp.  These examples can serve as a starting point for your own project.
+The `examples` folder of this repository contains some example code that uses libusbp.
+These examples can serve as a starting point for your own project.
 
 
 ## Versioning
@@ -151,16 +190,25 @@ The `examples` folder of this repository contains some example code that uses li
 The version numbers used by this library follow the rules of [Semantic Versioning 2.0.0](http://semver.org/).
 
 A backwards-incompatible version of this library might be released in the future.
-If that happens, the new version will have a different major version number: its version number will be 2.0.0 and it will be known as libusbp-2 to `pkg-config`.
-This library was designed to support having different major versions installed side-by-side on the same computer, so you could have both libusbp-1 and libusbp-2 installed at the same time.
+If that happens, the new version will have a different major version number: its version number
+will be 2.0.0 and it will be known as libusbp-2 to `pkg-config`.
+This library was designed to support having different major versions installed side-by-side on
+the same computer, so you could have both libusbp-1 and libusbp-2 installed at the same time.
 However, you would not be able to use both versions from a single program.
 
-If you write software that depends on libusbp, we recommend specifying which major version of libusbp your software uses in both the documentation of your software and in the scripts used to build it.  Scripts or instructions for downloading the source code of libusbp should use a branch name to ensure that they downlod the latest version of the code for a given major version number.  For example, the branch of this repository named "v1-latest" will always point to the latest release of libusbp-1.
+If you write software that depends on libusbp, we recommend specifying which major version of
+libusbp your software uses in both the documentation of your software and in the scripts used
+to build it.  Scripts or instructions for downloading the source code of libusbp should use a
+branch name to ensure that they downlod the latest version of the code for a given major version
+number.  For example, the branch of this repository named "v1-latest" will always point to the
+latest release of libusbp-1.
 
 
 ## Documentation
 
-For detailed documentation of this library, see the header files `libusb.h` and `libusbp.hpp` in the `include` directory, and see the `.md` files in this directory.  You can also use [Doxygen](http://doxygen.org/) to generate documentation from those files.
+For detailed documentation of this library, see the header files `libusb.h` and `libusbp.hpp` in
+the `include` directory, and see the `.md` files in this directory.
+You can also use [Doxygen](http://doxygen.org/) to generate documentation from those files.
 
 
 ## Version history

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -1,0 +1,21 @@
+if (NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+    message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif ()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach (file ${files})
+    message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+    if (IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+        exec_program("@CMAKE_COMMAND@"
+            ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+            OUTPUT_VARIABLE rm_out
+            RETURN_VALUE rm_retval
+        )
+        if (NOT "${rm_retval}" STREQUAL 0)
+            message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+        endif ()
+    else (IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+        message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+    endif ()
+endforeach ()


### PR DESCRIPTION
This commit enables a clean uninstall of the `libusbp` library from the system by using a terminal command.
The procedure is handled by `cmake` and `make`.
A note on how to proceed has been added to README.md .