### PR TITLE
Replace -Wall by /W3 for Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,8 +67,14 @@ set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 # Warn about everything.
+if (MSVC)
+set (CMAKE_C_FLAGS "/W3 ${CMAKE_C_FLAGS}")
+set (CMAKE_CXX_FLAGS "/W3 ${CMAKE_CXX_FLAGS}")
+else()
+# Warn about everything.
 set (CMAKE_C_FLAGS "-Wall -Wextra -pedantic ${CMAKE_C_FLAGS}")
 set (CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic ${CMAKE_CXX_FLAGS}")
+endif()
 
 if (ENABLE_GCOV)
   set (CMAKE_C_FLAGS "-fprofile-arcs -ftest-coverage ${CMAKE_C_FLAGS}")


### PR DESCRIPTION
This is needed for your project to compile with Visual Studio, else we get error:

cl : ligne de commande  error D8021: argument numérique non valide '/Wextra'

(French version)