### PR TITLE
Apple depreciations and clang preprocessor fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 CMakeCache.txt
 CMakeFiles
 Makefile
+build.ninja

--- a/src/libusbp_internal.h
+++ b/src/libusbp_internal.h
@@ -4,7 +4,7 @@
 #pragma once
 #include <libusbp_config.h>
 #include <libusbp.h>
-#if BUILD_SYSTEM_LIBUSBP_VERSION_MAJOR != LIBUSBP_VERSION_MAJOR
+#if (NOT BUILD_SYSTEM_LIBUSBP_VERSION_MAJOR == LIBUSBP_VERSION_MAJOR)
 #error Major version in libusbp.h disagrees with build system.
 #endif
 #endif

--- a/src/mac/iokit_mac.c
+++ b/src/mac/iokit_mac.c
@@ -19,7 +19,7 @@ libusbp_error * service_get_from_id(uint64_t id, io_service_t * service)
         return error_create("Failed to create a dictionary matching the ID.");
     }
 
-    *service = IOServiceGetMatchingService(kIOMasterPortDefault, dict);
+    *service = IOServiceGetMatchingService(kIOMainPortDefault, dict);
     if (*service == MACH_PORT_NULL)
     {
         return error_create("Failed to find service with ID 0x%" PRIx64 ".", id);

--- a/src/mac/list_mac.c
+++ b/src/mac/list_mac.c
@@ -53,7 +53,7 @@ libusbp_error * libusbp_list_connected_devices(
         // IOServiceGetMatchingServices consumes one reference to dict,
         // so we don't have to CFRelease it.
         kern_return_t result = IOServiceGetMatchingServices(
-            kIOMasterPortDefault, dict, &iterator);
+            kIOMainPortDefault, dict, &iterator);
         dict = NULL;
         if (result != KERN_SUCCESS)
         {


### PR DESCRIPTION
A few small changes for working cleanly on MacOS with VSCode and Clang.