### PR TITLE
Fix windows/msvc error LNK2001: unresolved external symbol GUID_DEVINTERFACE_USB_DEVICE

### DIFF
--- a/src/libusbp_internal.h
+++ b/src/libusbp_internal.h
@@ -33,6 +33,7 @@
 #include <devpropdef.h>
 #include <setupapi.h>
 #include <cfgmgr32.h>
+#include <initguid.h>
 #include <usbiodef.h>
 #include <usbioctl.h>
 #include <stringapiset.h>


### PR DESCRIPTION
When added as a CMake submodule to our project, on Windows using MSVC we get:

```
error LNK2001: unresolved external symbol GUID_DEVINTERFACE_USB_DEVICE
```

[This Stackoverflow answer](https://stackoverflow.com/a/48550614) suggests including `initguid.h` before `usbiodef.h` which solves the issue for us.